### PR TITLE
Ensure Nextgenapps credits display in black

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,12 @@
 </head>
 <body>
 <header>
-  <div>
+  <div class="header-brand">
     <h1>SafeBite HACCP</h1>
     <div class="sub" id="businessSub">Offline logboek • <span id="todayLabel"></span></div>
   </div>
-  <div class="actions">
+  <div class="header-meta">
+    <div class="sub dev-credit">Ontwikkeld door <a href="https://nextgenapps.nl" target="_blank" rel="noopener">Nextgenapps.nl</a></div>
     <button class="secondary" id="installBtn" style="display:none">Installeren</button>
   </div>
 </header>
@@ -273,7 +274,7 @@
   </section>
 </div>
 
-<footer>© 2025 SafeBite (MVP). Geen juridisch advies.</footer>
+<footer>© 2025 SafeBite. <span class="footer-credit">Ontwikkeld door <strong><a href="https://nextgenapps.nl" target="_blank" rel="noopener">Nextgenapps.nl</a></strong></span>.</footer>
 
 <script defer src="app.js"></script>
 <script type="module" src="auth.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -10,9 +10,12 @@
 }
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;background:var(--bg);color:var(--fg)}
-header{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;background:var(--accent);border-bottom:2px solid #000;position:sticky;top:0;z-index:10}
+header{display:flex;align-items:flex-start;justify-content:space-between;padding:14px 16px;background:var(--accent);border-bottom:2px solid #000;position:sticky;top:0;z-index:10}
 header h1{margin:0;font-size:20px}
 header .sub{font-size:12px;opacity:.8}
+header .dev-credit{margin:0;font-weight:600;text-align:right;color:#000;opacity:1}
+header .dev-credit a{color:inherit;text-decoration:none;border-bottom:1px dotted currentColor}
+.header-meta{display:flex;flex-direction:column;align-items:flex-end;gap:8px}
 nav{display:flex;gap:8px;flex-wrap:wrap;padding:10px 16px;background:#fff;border-bottom:1px solid #ddd;position:sticky;top:54px;z-index:9}
 nav button{border:1px solid #000;background:#fff;padding:8px 10px;border-radius:999px;cursor:pointer}
 nav button.active{background:#000;color:#fff}
@@ -35,6 +38,8 @@ textarea{min-height:80px}
 button.primary{background:#000;color:#fff;border:1px solid #000;padding:10px 12px;border-radius:10px;cursor:pointer}
 button.secondary{background:#fff;border:1px solid #000;padding:10px 12px;border-radius:10px;cursor:pointer}
 footer{padding:40px 16px;text-align:center;color:#666}
+footer .footer-credit{color:#000}
+footer a{color:inherit;text-decoration:none;border-bottom:1px dotted currentColor}
 .kv{display:grid;grid-template-columns:180px 1fr;gap:8px;font-size:13px}
 hr{border:none;border-top:1px dashed #ccc;margin:12px 0}
 .warning{color:var(--danger);font-weight:600}


### PR DESCRIPTION
## Summary
- explicitly style the header developer credit so it renders in solid black text
- wrap the footer credit in a span and style it to keep the Nextgenapps link black

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcd7396fbc832ebdc20195c5453fb8